### PR TITLE
fixed unusual movement of header

### DIFF
--- a/src/components/books/Index.jsx
+++ b/src/components/books/Index.jsx
@@ -28,8 +28,10 @@ const Index = () => {
 
   return (
     <div className='m-10'>
-      <Filter onStateChange={handleFilterChange} />
-      <div className='flex flex-wrap gap-6'>
+      <div className="absolute top-10 left-12 mx-10 w-full z-5 flex justify-center">
+        <Filter onStateChange={handleFilterChange} />
+      </div>
+      <div className='flex flex-wrap gap-6 justify-around pt-24'>
         {data.length > 0 ? (
           data.map((res, i) => (
             <Card

--- a/src/components/challenges/Index.jsx
+++ b/src/components/challenges/Index.jsx
@@ -28,8 +28,10 @@ const Index = () => {
 
   return (
     <div className='m-10'>
-      <Filter onStateChange={handleFilterChange} />
-      <div className='flex flex-wrap gap-6'>
+      <div className="absolute top-10 left-12 mx-10 w-full z-5 flex justify-center">
+        <Filter onStateChange={handleFilterChange} />
+      </div>
+      <div className='flex flex-wrap gap-6 justify-around pt-24'>
         {data.length > 0 ? (
           data.map(
             (res, i) =>

--- a/src/components/tools/Index.jsx
+++ b/src/components/tools/Index.jsx
@@ -28,8 +28,10 @@ const Index = () => {
 
   return (
     <div className='m-10'>
-      <Filter onStateChange={handleFilterChange} />
-      <div className='flex flex-wrap gap-6'>
+      <div className="absolute top-10 left-12 mx-10 w-full z-5 flex justify-center">
+        <Filter onStateChange={handleFilterChange} />
+      </div>
+      <div className='flex flex-wrap gap-6 justify-around pt-24'>
         {data.length > 0 ? (
           data.map((res, i) => (
             <Card

--- a/src/components/videos/Index.jsx
+++ b/src/components/videos/Index.jsx
@@ -28,8 +28,10 @@ const Index = () => {
 
   return (
     <div className='m-10'>
-      <Filter onStateChange={handleFilterChange} />
-      <div className='flex flex-wrap gap-6'>
+      <div className="absolute top-10 left-12 mx-10 w-full z-5 flex justify-center">
+        <Filter onStateChange={handleFilterChange} />
+      </div>
+      <div className='flex flex-wrap gap-6 justify-around pt-24'>
         {data.length > 0 ? (
           data.map((res, i) => (
             <Card

--- a/src/components/websites/Index.jsx
+++ b/src/components/websites/Index.jsx
@@ -28,8 +28,10 @@ const Index = () => {
 
   return (
     <div className='m-10'>
-      <Filter onStateChange={handleFilterChange} />
-      <div className='flex flex-wrap gap-6'>
+      <div className="absolute top-10 left-12 mx-10 w-full z-5 flex justify-center">
+        <Filter onStateChange={handleFilterChange} />
+      </div>
+      <div className='flex flex-wrap gap-6 justify-around pt-24'>
         {data.length > 0 ? (
           data.map((res, i) => (
             <Card


### PR DESCRIPTION
Fixes issue:
#432 

Changes proposed:
Initially, the filter header was changing its position according to the width of the block bottom to it, which was a very unusual movement. Hence, in this pull request, I have solved that issue. Now filter header is fixed at the center, it will not change its position with respect to the width of the cards.

Screenshot:
![ezgif com-video-to-gif](https://github.com/jayk-gupta/web-resources-project/assets/77767357/8d1e8481-1844-4db9-b547-9c194fc351ac)

