### PR TITLE
[DOCS]: Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 
 6. Type the command `git clone [https://github.com/<your_github_username>/web-resources-project.git]` (This will download the repository to your local machine)
 
-## ⬇️ Prerequites
+## ⬇️ Prerequisites
   - **Node JS**
   -  **pnpm**
 
@@ -82,7 +82,7 @@
 4. Add the details of your resource: Here's an example
 ```
 {
-    "tag" : "css"
+    "tag" : "css",
     "title": "CodeWell",
     "description": "Improve your HTML and CSS skills by practicing on real design templates.With Codewell, you can browse high quality Figma templates that you can use to sharpen your HTML and CSS skills.",
     "link": "https://www.codewell.cc/",


### PR DESCRIPTION
Fixed minor typos in README.md.

The word "Prerequites" was misspelled and changed to "Prerequisites".
Added missing comma after "css" in this JSON object:

```json
{
  "tag": "css",
  "title": "CodeWell",
  "description": "Improve your HTML and CSS skills by practicing on real design templates. With Codewell, you can browse high-quality Figma templates that you can use to sharpen your HTML and CSS skills.",
  "link": "https://www.codewell.cc/",
  "img": "https://user-images.githubusercontent.com/100681165/238244473-00725538-ef4d-4ece-8fd7-11e6b999b895.png"
}
```