### PR TITLE
Made License in readme navigate to LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To star this repository, simply click on the **Star** button at the top-right co
 
 
 # License
-MIT License. This project is licensed under the MIT License.
+[MIT License](./LICENSE). This project is licensed under the MIT License.
 <p align="right"><a href="#top">Back to top</a></p>
 </div>
 


### PR DESCRIPTION
Fixes #398 

Made License text in the readme file navigate to the License file present in the repo so that clicking on it helps the user view the License file